### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/KittenCN/stock_prediction/security/code-scanning/1](https://github.com/KittenCN/stock_prediction/security/code-scanning/1)

The best way to fix this problem is to add an explicit `permissions` block to restrict the workflow's access to the GITHUB_TOKEN, thereby adhering to the principle of least privilege. Since the current steps only run tests and install dependencies (all requiring only read access), we should add `permissions: contents: read` at the top level of the workflow (immediately after the workflow name, before `on:`) to make this the default for all contained jobs. This approach minimally alters the file and does not affect the workflow's existing functionality. No additional methods, imports, or definitions are required—just the insertion of the permissions block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
